### PR TITLE
Fix: Set asteroid color to grey

### DIFF
--- a/game.js
+++ b/game.js
@@ -383,8 +383,8 @@
             }
             ctx.closePath();
 
-            ctx.fillStyle = this.isFragment ? '#a0a0a0' : '#8b4513'; // Lighter grey for fragments, brown for asteroids
-            ctx.strokeStyle = this.isFragment ? '#cccccc' : '#a0522d'; // Lighter outlines
+            ctx.fillStyle = '#a0a0a0';
+            ctx.strokeStyle = '#cccccc';
             ctx.lineWidth = 1.5;
             ctx.fill();
             ctx.stroke();


### PR DESCRIPTION
I changed the Asteroid.draw() method to use a consistent grey color for all asteroids and fragments. Previously, initial asteroids were brown, and subsequent ones were unintentionally grey due to the logic tied to `gameTime` influencing the `isFragment` flag. This change ensures all asteroids and fragments now correctly appear grey as per your requirements.